### PR TITLE
disable authorization plugin until ActiveMQ MQTT bug is fixed

### DIFF
--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -55,8 +55,8 @@
               <authenticationUser username="mcollective" password="secret" groups="mcollective,admins,everyone"/>
             </users>
           </simpleAuthenticationPlugin>
+<% if !@mqtt_enabled_real -%>
 <%# disable authorization plugin until ActiveMQ MQTT bug is fixed %>
-<% if @mqtt_enabled_real != nil -%>
           <authorizationPlugin>
             <map>
               <authorizationMap>


### PR DESCRIPTION
I took a stab at the erb syntax, not sure if it's entirely correct
